### PR TITLE
Update PKGBUILD

### DIFF
--- a/package/arch/lico-git/PKGBUILD
+++ b/package/arch/lico-git/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="Simple and flexible dotfiles manager written in Golang"
 arch=('x86_64')
 url="https://github.com/Hayao0819/lico"
 license=('MIT' 'custom')
-makedepends=('git' 'go')
+makedepends=('git' 'go' 'goreleaser')
 source=(
     "git+https://github.com/Hayao0819/lico.git"
 )
@@ -16,17 +16,17 @@ md5sums=("SKIP")
 
 pkgver(){
     cd "$srcdir/lico"
-    git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+    git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build(){
     cd "$srcdir/lico"
-    "$srcdir/go.sh" build
+    "$srcdir/lico/go.sh" build
 }
 
 package(){
     mkdir -p "${pkgdir}/usr/bin/"
-    cp "${srcdir}/lico" "${pkgdir}/usr/bin/"
+    cp -r "${srcdir}/lico" "${pkgdir}/usr/bin/"
     chmod 755 "${pkgdir}/usr/bin/"
 }
 


### PR DESCRIPTION
PKGBUILDを最低限動くようにしました。
- パッケージ作成時の依存関係にgoreleaserを追加
- pkgver内のgit describe に --tagsを追加
- build内のgo.shのパスを修正
- package内のcdに -r を追加