### PR TITLE
Fix: PKGBUILD

### DIFF
--- a/package/arch/lico-git/PKGBUILD
+++ b/package/arch/lico-git/PKGBUILD
@@ -26,8 +26,8 @@ build(){
 
 package(){
     mkdir -p "${pkgdir}/usr/bin/"
-    cp -r "${srcdir}/lico" "${pkgdir}/usr/bin/"
-    chmod 755 "${pkgdir}/usr/bin/"
+    cp "${srcdir}/lico/lico" "${pkgdir}/usr/bin/"
+    chmod 755 "${pkgdir}/usr/bin/lico"
 }
 
 


### PR DESCRIPTION
本コミットは、ビルドされたバイナリのみを/usr/bin/配下にインストールするものです。

ディレクトリをパッケージングする必要はありません。
そのため、bbace1645ca2e391533c137745a22261b432964e を修正する必要があります。

(誤ったパッチを送信してしまい、申し訳ございせんでした)